### PR TITLE
Adds handsfree:mouseDown|Drag|Up events and plugin hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,16 @@ const myPlugin = handsfree.use({
   onDisable: (handsfree) => {},
 
   // Called when .enable() is explicitely called on this plugin
-  onEnable: (handsfree) => {}
+  onEnable: (handsfree) => {},
+
+  // Called the first frame a face clicks
+  onMouseDown: (face, faceIndex) => {},
+
+  // Called every frame after a face clicks and is still in "click mode"
+  onMouseDrag: (face, faceIndex) => {},
+
+  // Called after a face releases a click
+  onMouseUp: (face, faceIndex) => {}
 })
 ```
 
@@ -272,6 +281,48 @@ window.addEventListener('handsfree:ready', () => {
   // do stuff when handsfree is ready
 })
 ```
+
+### handsfree.mouseDown
+```js
+/**
+ * Called the first frame that a face clicks
+ */
+window.addEventListener('handsfree:mouseDown', (ev) => {
+  const face = ev.detail.face
+  const faceIndex = ev.detail.faceIndex
+
+  // Do things with face and faceIndex here
+})
+```
+
+### handsfree.mouseDrag
+```js
+/**
+ * Called every frame after a face clicks and is still in "click mode"
+ */
+window.addEventListener('handsfree:mouseDrag', (ev) => {
+  const face = ev.detail.face
+  const faceIndex = ev.detail.faceIndex
+
+  // Do things with face and faceIndex here
+})
+```
+
+### handsfree.mouseUp
+```js
+/**
+ * Called when a face releases a click
+ */
+window.addEventListener('handsfree:mouseUp', (ev) => {
+  const face = ev.detail.face
+  const faceIndex = ev.detail.faceIndex
+
+  // Do things with face and faceIndex here
+})
+```
+
+## Deprecated Events
+The following events are still being used but will be deprecated during the next major release:
 
 ### handsfree-trackFaces
 An alternative to plugins is to listen in on the window's `handsfree-trackFaces` event:

--- a/handsfree.js/Plugin.js
+++ b/handsfree.js/Plugin.js
@@ -32,6 +32,11 @@ module.exports = Handsfree => {
     // Call onUse hook
     !config._isDisabled && config.onUse && config.onUse(this)
 
+    // Call onMouseDown, onMouseDrag, onMouseUp
+    if (config.onMouseDown) window.addEventListener('handsfree:mouseDown', (ev) => {config.onMouseDown(ev.detail.face, ev.detail.id)})
+    if (config.onMouseDrag) window.addEventListener('handsfree:mouseDrag', (ev) => {config.onMouseDrag(ev.detail.face, ev.detail.id)})
+    if (config.onMouseUp) window.addEventListener('handsfree:mouseUp', (ev) => {config.onMouseUp(ev.detail.face, ev.detail.id)})
+
     // Sort alphabetically
     let newPlugins = {}
     Object.keys(this.plugin).sort().forEach(key => newPlugins[key] = this.plugin[key])

--- a/handsfree.js/plugins/SmileClick.js
+++ b/handsfree.js/plugins/SmileClick.js
@@ -37,12 +37,14 @@ module.exports = {
       if (smileFactor < 0) smileFactor = 0
       if (smileFactor > 1) smileFactor = 1
 
+      // Update states and fire events
       instance.faces[faceIndex].cursor.state = this.updateMouseStates({
         face,
         faceIndex,
         instance,
         smileFactor
       })
+      this.maybeFireEvents(instance.faces, faceIndex)
     })
 
     return instance.faces
@@ -55,8 +57,10 @@ module.exports = {
   updateMouseStates (state) {
     if (state.smileFactor >= 1) {
       this.mouseDrag[state.faceIndex] = this.mouseDowned[state.faceIndex]
+      // Every frame after first frame of click
       if (this.mouseDowned[state.faceIndex]) {
         this.mouseDown[state.faceIndex] = false
+      // First frame of click
       } else {
         this.mouseDowned[state.faceIndex] = true
         this.mouseDown[state.faceIndex] = true
@@ -81,6 +85,31 @@ module.exports = {
       mouseDown: this.mouseDown[state.faceIndex],
       mouseDrag: this.mouseDrag[state.faceIndex],
       mouseUp: this.mouseUp[state.faceIndex]
+    }
+  },
+
+  /**
+   * Maybe fire events
+   */
+  maybeFireEvents (faces, index) {
+    const state = faces[index].cursor.state
+    let eventName = ''
+    
+    if (state.mouseDown) {
+      eventName = 'mouseDown'
+    } else if (state.mouseDrag) {
+      eventName = 'mouseDrag'
+    } else if (state.mouseUp) {
+      eventName = 'mouseUp'
+    }
+
+    if (eventName) {
+      window.dispatchEvent(new CustomEvent(`handsfree:${eventName}`, {
+        detail: {
+          face: faces[index],
+          id: index
+        }
+      }))
     }
   },
 

--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -206,7 +206,16 @@
                     onDisable: (handsfree) => {},
 
                     // Called when .enable() is explicitely called on this plugin
-                    onEnable: (handsfree) => {}
+                    onEnable: (handsfree) => {},
+
+                    // Called the first frame a face clicks
+                    onMouseDown: (face, faceIndex) => {},
+
+                    // Called every frame after a face clicks and is still in "click mode"
+                    onMouseDrag: (face, faceIndex) => {},
+
+                    // Called after a face releases a click
+                    onMouseUp: (face, faceIndex) => {}
                   })
 
               p Additionally, every plugin has a <code>.disable()</code> and an <code>.enable()</code> method, which sets a <code>._isDisabled</code> flag to either true or false:
@@ -279,7 +288,36 @@
                       // Enable .start() buttons
                     })
 
-                  
+                    /**
+                     * Called the first frame that a face clicks
+                     */
+                    window.addEventListener('handsfree:mouseDown', (ev) => {
+                      const face = ev.detail.face
+                      const faceIndex = ev.detail.faceIndex
+
+                      // Do things with face and faceIndex here
+                    })
+
+                    /**
+                     * Called every frame after a face clicks and is still in "click mode"
+                     */
+                    window.addEventListener('handsfree:mouseDrag', (ev) => {
+                      const face = ev.detail.face
+                      const faceIndex = ev.detail.faceIndex
+
+                      // Do things with face and faceIndex here
+                    })
+
+                    /**
+                     * Called when a face releases a click
+                     */
+                    window.addEventListener('handsfree:mouseUp', (ev) => {
+                      const face = ev.detail.face
+                      const faceIndex = ev.detail.faceIndex
+
+                      // Do things with face and faceIndex here
+                    })
+
                     /**
                     * Bind to the handsfree-trackFaces event, which is called once per frame
                     * @param {Handsfree} ev.detail.scope The handsfree instance

--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -17,7 +17,8 @@
               img.mr-2(src='https://travis-ci.org/BrowseHandsfree/handsfreeJS.svg?branch=master')
             a(href='https://codecov.io/gh/BrowseHandsfree/handsfreeJS')
               img.mr-2(src='https://img.shields.io/codecov/c/github/BrowseHandsfree/handsfreeJS/master.svg?style=flat')
-            a.github-button(href='https://github.com/browsehandsfree/handsfreejs' data-show-count='true' aria-label='Star browsehandsfree/handsfreejs on GitHub' data-icon='octicon-star') GitHub
+            span(style='margin-top: 5px; display: inline-block; vertical-align: middle')
+              a.github-button(href='https://github.com/browsehandsfree/handsfreejs' data-show-count='true' aria-label='Star browsehandsfree/handsfreejs on GitHub' data-icon='octicon-star') GitHub
           p.subheading.font-weight-regular
             | A drop-in library for adding handsfree interfaces to any website, service, and Internet of Thing. Runs on any device that supports <a href="https://caniuse.com/#feat=stream">getUserMedia()</a>
           p.text-xs-center

--- a/src/components/holodeck/Landing.vue
+++ b/src/components/holodeck/Landing.vue
@@ -6,7 +6,7 @@ div
       v-flex(xs12 md6 lg8 style='height: 500px')
       v-flex.handsfree-show-when-stopped(xs12 md6 lg4)
         v-card(light)
-          v-card-media
+          v-responsive
             v-img(src='https://media.giphy.com/media/9wZID81vMLTwJ5JKps/giphy.gif')
           v-card-text
             //- v-img(src='https://media.giphy.com/media/4HgnusIh1i8MzRoaOm/giphy.gif')

--- a/src/components/holodeck/handsfree.vue
+++ b/src/components/holodeck/handsfree.vue
@@ -65,7 +65,7 @@ export default {
         /**
          * Toggle cursor
          */
-        onMouseDown (face) {this.showCursor = !this.showCursor},
+        onMouseDown () {this.showCursor = !this.showCursor},
         
         /**
          * This is called on each webcam frame

--- a/src/components/holodeck/handsfree.vue
+++ b/src/components/holodeck/handsfree.vue
@@ -61,6 +61,11 @@ export default {
           rotationY: 0,
           rotationZ: 0
         },
+
+        /**
+         * Toggle cursor
+         */
+        onMouseDown (face) {this.showCursor = !this.showCursor},
         
         /**
          * This is called on each webcam frame
@@ -68,11 +73,6 @@ export default {
          */
         onFrame (faces) {
           faces.forEach(face => {
-            // Show/hide cursor
-            if (face.cursor.state.mouseDown) {
-              this.showCursor = !this.showCursor
-            }
-
             // Hide cursor when over the iframe
             if (face.cursor.$target && face.cursor.$target.nodeName === 'CANVAS') {
               handsfree.cursor.$el.style.display = this.showCursor ? 'inherit' : 'none'

--- a/src/components/youtube/Landing.vue
+++ b/src/components/youtube/Landing.vue
@@ -30,7 +30,7 @@ v-container(grid-list-md)
 
     v-flex(xs12 md6 lg4)
       v-card(light)
-        v-card-media
+        v-responsive
           v-img(src='https://media.giphy.com/media/4HgnusIh1i8MzRoaOm/giphy.gif')
         v-card-text
           div.mt-3

--- a/src/demo/paper.js
+++ b/src/demo/paper.js
@@ -27,44 +27,42 @@ window.addEventListener('load', () => {
       tool.minDistance = 20
     },
 
-    onFrame (faces) {
-      if (!$canvas) return
-      
-      faces.forEach((face, faceIndex) => {
-        // Only catch events when the cursor is over the canvas
-        if (face.cursor.$target === $canvas) {
-          // Start path, select a new color
-          if (face.cursor.state.mouseDown) {
-            this.setLastPoint(face, faceIndex)
-            path = new paper.Path()
-            path.strokeColor = {
-              hue: Math.random() * 360,
-              saturation: 1,
-              brightness: 1
-            }
-            path.strokeJoin = 'round'
-            path.strokeWidth = face.scale / 10
-            path.moveTo(this.lastPoint[faceIndex])
-          }
+    /**
+     * Start path, select new color
+     */
+    onMouseDown (face, faceIndex) {
+      if (face.cursor.$target !== $canvas) return
 
-          // Draw the path
-          if (face.cursor.state.mouseDrag) {
-            const newPoint = this.getPoint(face)
+      this.setLastPoint(face, faceIndex)
+      path = new paper.Path()
+      path.strokeColor = {
+        hue: Math.random() * 360,
+        saturation: 1,
+        brightness: 1
+      }
+      path.strokeJoin = 'round'
+      path.strokeWidth = face.scale / 10
+      path.moveTo(this.lastPoint[faceIndex])
+    },
 
-            if (newPoint.getDistance(this.getLastPoint(faceIndex)) > tool.minDistance) {
-              path.strokeWidth = Math.max(face.scale / 2 - 50, 1)
-              path.lineTo(new paper.Point(
-                face.cursor.x - $canvas.getBoundingClientRect().left,
-                face.cursor.y - $canvas.getBoundingClientRect().top
-              ))
-              paper.view.draw()
-              path.smooth()
+    /**
+     * Draw the path
+     */
+    onMouseDrag (face, faceIndex) {
+      if (face.cursor.$target !== $canvas) return
+      const newPoint = this.getPoint(face)
 
-              this.setLastPoint(face, faceIndex)
-            }
-          }
-        }
-      })
+      if (newPoint.getDistance(this.getLastPoint(faceIndex)) > tool.minDistance) {
+        path.strokeWidth = Math.max(face.scale / 2 - 50, 1)
+        path.lineTo(new paper.Point(
+          face.cursor.x - $canvas.getBoundingClientRect().left,
+          face.cursor.y - $canvas.getBoundingClientRect().top
+        ))
+        paper.view.draw()
+        path.smooth()
+
+        this.setLastPoint(face, faceIndex)
+      }
     },
 
     /**


### PR DESCRIPTION
The following new global events have been added:

```js
/**
  * Called the first frame that a face clicks
  */
window.addEventListener('handsfree:mouseDown', (ev) => {
  const face = ev.detail.face
  const faceIndex = ev.detail.faceIndex

  // Do things with face and faceIndex here
})

/**
  * Called every frame after a face clicks and is still in "click mode"
  */
window.addEventListener('handsfree:mouseDrag', (ev) => {
  const face = ev.detail.face
  const faceIndex = ev.detail.faceIndex

  // Do things with face and faceIndex here
})

/**
  * Called when a face releases a click
  */
window.addEventListener('handsfree:mouseUp', (ev) => {
  const face = ev.detail.face
  const faceIndex = ev.detail.faceIndex

  // Do things with face and faceIndex here
})
```

To simplify development, plugins now have the following callbacks:

```js
handsfree.use({
  name: 'myPlugin',

  // Called the first frame a face clicks
  onMouseDown: (face, faceIndex) => {},

  // Called every frame after a face clicks and is still in "click mode"
  onMouseDrag: (face, faceIndex) => {},

  // Called after a face releases a click
  onMouseUp: (face, faceIndex) => {}
})
```